### PR TITLE
Add functionality to read Hibernate configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ nb-configuration.xml
 release.properties
 pom.xml.releaseBackup
 pom.xml.tag
+
+# Hibernate configuration
+server/hibernate.properties

--- a/server/src/main/java/il/cshaifasweng/OCSFMediatorExample/server/PropertiesLoader.java
+++ b/server/src/main/java/il/cshaifasweng/OCSFMediatorExample/server/PropertiesLoader.java
@@ -1,0 +1,22 @@
+package il.cshaifasweng.OCSFMediatorExample.server;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class PropertiesLoader {
+
+    public static Properties loadFile(File file) {
+        Properties properties = new Properties();
+        try (InputStream input = new FileInputStream(file)) {
+            properties.load(input);
+            // Properties loaded successfully
+        } catch (IOException e) {
+            e.printStackTrace();
+            // Error occurred while loading properties
+        }
+        return properties;
+    }
+}

--- a/server/src/main/java/il/cshaifasweng/OCSFMediatorExample/server/SimpleServer.java
+++ b/server/src/main/java/il/cshaifasweng/OCSFMediatorExample/server/SimpleServer.java
@@ -14,6 +14,7 @@ import org.hibernate.service.ServiceRegistry;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import java.io.File;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -48,7 +49,14 @@ public class SimpleServer extends AbstractServer {
 	}
 
 	private static SessionFactory getSessionFactory() throws HibernateException {
+		String currentDir = System.getProperty("user.dir");
+		System.out.println("Current Working Directory: " + currentDir);
 		Configuration configuration = new Configuration();
+		File propertiesFile = new File("./hibernate.properties");
+		if (propertiesFile.exists()) {
+			System.out.println("New config file found in working directory.");
+			configuration.setProperties(PropertiesLoader.loadFile(propertiesFile));
+		}
 
 		// Add ALL of your entities here. You can also try adding a whole package.
 		configuration.addAnnotatedClass(Task.class);


### PR DESCRIPTION
Now you can add "hibernate.properties" in the current working directory, and it will apply all properties found in it, overwriting properties in ".../resources/hibernate.properties". If it's not found, then it doesn't do anything. The default properties file is always loaded first.

When running the server code (without JAR), it will look for the file in "server/". When running a JAR it's looking in the current working directory.